### PR TITLE
ci: add containerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**
+!src/
+!Cargo.toml
+!Cargo.lock
+!.cargo/

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,49 @@
+---
+name: Build container image
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
+jobs:
+  build-and-push-penumbra:
+    runs-on: buildjet-16vcpu-ubuntu-2004
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Docker Hub container registry (for pulls)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to the GitHub container registry (for pushes)
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/penumbra-zone/osiris
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          file: Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,21 @@
+# Pull from Penumbra container, so we can grab a recent `pcli` without
+# needing to compile from source.
+FROM ghcr.io/penumbra-zone/penumbra:main AS penumbra
+FROM docker.io/rust AS builder
+
+RUN apt-get update && apt-get install -y \
+        libssl-dev git-lfs clang
+# Shallow clone since we only want most recent HEAD; this should change
+# if/when we want to support specific refs, such as release tags, for Penumbra deps.
+RUN git clone --depth=1 https://github.com/penumbra-zone/penumbra /app/penumbra
+COPY . /app/osiris
+WORKDIR /app/osiris
+RUN cargo build --release
+
+FROM docker.io/debian:stable-slim
+RUN groupadd --gid 1000 penumbra \
+        && useradd -m -d /home/penumbra -g 1000 -u 1000 penumbra
+COPY --from=builder /app/osiris/target/release/osiris /usr/bin/osiris
+COPY --from=penumbra /bin/pcli /usr/bin/pcli
+WORKDIR /home/penumbra
+USER penumbra


### PR DESCRIPTION
Builds a container image for Osiris, so we don't have to build it from source on every deployment.