### PR TITLE
ci: add build args for container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,6 +3,11 @@ name: Build container image
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      penumbra_version:
+        description: 'Git ref (e.g. branch or tag) of Penumbra repo for building'
+        default: "main"
+        required: true
   push:
     branches:
       - main
@@ -45,7 +50,11 @@ jobs:
           platforms: linux/amd64
           file: Containerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          # We include a tag with the associated Penumbra, e.g. `penumbra-v0.57.0`.
+          # This is important to maintain compatibility with a long-running testnet.
+          tags: ${{ steps.meta.outputs.tags }},penumbra-${{ inputs.penumbra_version }}
+          build-args: |
+            PENUMBRA_VERSION=${{ inputs.penumbra_version }}
           # We disable layer caching to ensure that the most recent penumbra repo is used.
           # Otherwise, the static git url for the repo will always result in a cache hit.
           # TODO: update with dynamic build-args using e.g. current date to bust cache.

--- a/Containerfile
+++ b/Containerfile
@@ -1,13 +1,14 @@
+ARG PENUMBRA_VERSION=main
+# ARG PENUMBRA_VERSION=v0.54.1
 # Pull from Penumbra container, so we can grab a recent `pcli` without
 # needing to compile from source.
-FROM ghcr.io/penumbra-zone/penumbra:main AS penumbra
+FROM ghcr.io/penumbra-zone/penumbra:${PENUMBRA_VERSION} AS penumbra
 FROM docker.io/rust:1-bullseye AS builder
 
+ARG PENUMBRA_VERSION=main
 RUN apt-get update && apt-get install -y \
         libssl-dev git-lfs clang
-# Shallow clone since we only want most recent HEAD; this should change
-# if/when we want to support specific refs, such as release tags, for Penumbra deps.
-RUN git clone --depth=1 https://github.com/penumbra-zone/penumbra /app/penumbra
+RUN git clone --depth 1 --branch "${PENUMBRA_VERSION}" https://github.com/penumbra-zone/penumbra /app/penumbra
 COPY . /app/osiris
 WORKDIR /app/osiris
 RUN cargo build --release


### PR DESCRIPTION
Let's permit building against specific versions of penumbra. We should still default to "main" for latest, but we'll want different versions at other times.