### PR TITLE
fix: exit on websocket error

### DIFF
--- a/src/binance_fetcher.rs
+++ b/src/binance_fetcher.rs
@@ -83,6 +83,7 @@ impl BinanceFetcher {
             match e {
                 err => {
                     tracing::error!(?err, "error in web socket event loop");
+                    anyhow::bail!(format!("Failed in web socket loop, exiting"));
                 }
             }
         }


### PR DESCRIPTION
If the websocket connection to the Binance API fails, the service should fail, which will trigger a service restart. Otherwise, the bot gets stuck. Refs #13.