### PR TITLE
chore: update penumbra deps layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,15 @@ license = "MIT OR Apache-2.0"
 [features]
 default = ["std", "parallel"]
 std = ["ark-ff/std"]
-parallel = ["penumbra-wallet/parallel", "penumbra-crypto/parallel"]
+parallel = ["penumbra-wallet/parallel"]
 
 [dependencies]
 # Penumbra dependencies
 penumbra-proto = { path = "../penumbra/crates/proto" }
-penumbra-crypto = { path = "../penumbra/crates/core/crypto" }
+penumbra-asset = { path = "../penumbra/crates/core/asset" }
+penumbra-num = { path = "../penumbra/crates/core/num" }
+penumbra-fee = { path = "../penumbra/crates/core/component/fee" }
+penumbra-keys = { path = "../penumbra/crates/core/keys" }
 penumbra-dex = { path = "../penumbra/crates/core/component/dex" }
 penumbra-custody = { path = "../penumbra/crates/custody" }
 penumbra-view = { path = "../penumbra/crates/view" }

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -34,7 +34,7 @@ pub struct Serve {
     /// The source address index in the wallet to use when dispensing tokens (if unspecified uses
     /// any funds available).
     #[clap(long = "source", default_value = "0")]
-    source_address: penumbra_crypto::keys::AddressIndex,
+    source_address: penumbra_keys::keys::AddressIndex,
     /// The websockets address to access the Binance API on.
     #[clap(long = "binance_ws", default_value = "wss://stream.binance.us:9443")]
     binance_ws: Url,

--- a/src/trader.rs
+++ b/src/trader.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, future, str::FromStr};
 use anyhow::Context;
 use binance::model::BookTickerEvent;
 use futures::{StreamExt, TryStreamExt};
-use penumbra_crypto::{asset::DenomMetadata, keys::AddressIndex, Amount, Fee, FullViewingKey};
+use penumbra_asset::asset::DenomMetadata;
 use penumbra_custody::{AuthorizeRequest, CustodyClient};
 use penumbra_dex::{
     lp::{
@@ -12,6 +12,9 @@ use penumbra_dex::{
     },
     DirectedUnitPair,
 };
+use penumbra_fee::Fee;
+use penumbra_keys::keys::{AddressIndex, FullViewingKey};
+use penumbra_num::Amount;
 use penumbra_proto::client::v1alpha1::LiquidityPositionsByPriceRequest;
 use penumbra_proto::client::v1alpha1::{
     specific_query_service_client::SpecificQueryServiceClient, LiquidityPositionsRequest,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use penumbra_crypto::keys::SpendKey;
+use penumbra_keys::keys::SpendKey;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 


### PR DESCRIPTION
We abolished the crypto crate as part of Testnet 56, so we must update our imports accordingly. Matches changes described in https://github.com/penumbra-zone/penumbra/issues/2765