### PR TITLE
feat: default to https for node url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-# this is way too complicated, the features in the penumbra crates need to be fixed
 [features]
-default = ["std", "parallel"]
-std = ["ark-ff/std"]
-parallel = ["penumbra-wallet/parallel"]
 
 [dependencies]
 # Penumbra dependencies
@@ -22,12 +16,9 @@ penumbra-keys = { path = "../penumbra/crates/core/keys" }
 penumbra-dex = { path = "../penumbra/crates/core/component/dex" }
 penumbra-custody = { path = "../penumbra/crates/custody" }
 penumbra-view = { path = "../penumbra/crates/view" }
-penumbra-wallet= { path = "../penumbra/crates/wallet" }
 penumbra-transaction = { path = "../penumbra/crates/core/transaction", features = ["download-proving-keys"] }
 
 # External dependencies
-ark-ff = "0.3"
-ark-serialize = "0.3"
 anyhow = "1"
 directories = "4.0.1"
 lazy_static = "1.4.0"
@@ -47,18 +38,3 @@ tonic = { version = "0.8.1", features = ["tls-webpki-roots", "tls"] }
 serde = { version = "1", features = ["derive"]}
 binance = { git = "https://github.com/wisespace-io/binance-rs.git" }
 url = "2"
-
-# External dependencies
-tendermint-config = "0.24.0-pre.1"
-# These are = dependencies to force the whole workspace's dependency tree to go
-# back onto 0.24.0-pre.1, which, unlike 0.24.0-pre.2, doesn't have
-# ecosystem-incompatible breaking changes to the prost version.
-#
-# Longer-term, we can't rely on the upstream to publish versions, so we should plan
-# to fork the crates and maintain our fork.
-tendermint-proto = "=0.24.0-pre.1"
-tendermint = "=0.24.0-pre.1"
-# We don't need this crate at all, but its upstream published a breaking change as
-# 0.7.1 (also prost-related), and depending on an exact version here will exclude
-# the bad update until it's yanked.
-ics23 = "=0.7.0"

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -29,7 +29,7 @@ pub struct Serve {
     #[clap(long, short)]
     data_dir: Option<PathBuf>,
     /// The URL of the pd gRPC endpoint on the remote node.
-    #[clap(short, long, default_value = "http://testnet.penumbra.zone:8080")]
+    #[clap(short, long, default_value = "https://grpc.testnet.penumbra.zone")]
     node: Url,
     /// The source address index in the wallet to use when dispensing tokens (if unspecified uses
     /// any funds available).


### PR DESCRIPTION
We've been using HTTPS URLs in the deployment spec for Osiris for a while now, ever since [0]. Here we update the default value in the CLI options, so we don't need to depend on the override.
    
[0] https://github.com/penumbra-zone/penumbra/pull/2685
