### PR TITLE
chore: bump tonic 0.9 -> 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rand = "0.8"
 reqwest = "0.11"
 indexmap = "1.8"
 chrono = { version = "0.4", features = ["serde"] }
-tonic = { version = "0.9", features = ["tls-webpki-roots", "tls"] }
+tonic = { version = "0.10", features = ["tls-webpki-roots", "tls"] }
 serde = { version = "1", features = ["derive"] }
 binance = { git = "https://github.com/wisespace-io/binance-rs.git" }
 url = "2"


### PR DESCRIPTION
Matches changes in [0]. Required to unbreak build.

[0] https://github.com/penumbra-zone/penumbra/pull/3192