### PR TITLE
feat: crash if tx plan submission fails

### DIFF
--- a/src/trader.rs
+++ b/src/trader.rs
@@ -237,7 +237,7 @@ where
                                 ?plan,
                                 "failed to update position"
                             );
-                            continue;
+                            return Err(e);
                         }
                     };
 


### PR DESCRIPTION
We want the app to crash if submission plan fails. Doing so will make the error more obvious, and also enable potential recovery via new app image.