### PR TITLE
build: pin binance dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,8 @@ indexmap = "1.8"
 chrono = { version = "0.4", features = ["serde"] }
 tonic = { version = "0.10", features = ["tls-webpki-roots", "tls"] }
 serde = { version = "1", features = ["derive"] }
-binance = { git = "https://github.com/wisespace-io/binance-rs.git" }
+# The commit `17ba6f3cedec7f5908e4cc2b3c39f61a778df2ec` from 2023-12-03 broke compilation,
+# so we pin the prior git revision.
+# binance = { git = "https://github.com/wisespace-io/binance-rs.git", rev = "17ba6f3cedec7f5908e4cc2b3c39f61a778df2ec" }
+binance = { git = "https://github.com/wisespace-io/binance-rs.git", rev = "3017e136cc4439c9b6a67fdccb76a7c3a94f8440" }
 url = "2"


### PR DESCRIPTION
The binance api merged a major change to the library, converting it to a cdylib crate, without bumping any versions. We were trailing the default branch on the upstream repo, so this change broke our builds. Pinning the most recent working version to unbreak.